### PR TITLE
ipv6 dns resolution support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-i-connect"
-version = "0.2.0"
+version = "0.2.1"
 build = "build.rs"
 edition = "2021"
 

--- a/examples/quick_dev.rs
+++ b/examples/quick_dev.rs
@@ -13,11 +13,10 @@ async fn main() -> Result<()> {
 			"http_hosts": [
 				"https://duckduckgo.com",
 				"https://rust-lang.org",
-				"https://apple.com"
 			],
 			"tcp_hosts": [
 				"duckduckgo.com:443",
-				"rust-lang.org:443"
+				"ipv6.google.com:80"
 			],
 		}),
 	);

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,0 +1,19 @@
+use crate::error::Error;
+use std::net::{SocketAddr, ToSocketAddrs};
+
+// This is the trait we'll use for DNS resolution
+pub trait DnsResolver {
+	fn resolve(&self, host: &str) -> Result<Vec<SocketAddr>, Error>;
+}
+
+// The default implementation that does the actual DNS resolution
+pub struct DefaultResolver;
+
+impl DnsResolver for DefaultResolver {
+	fn resolve(&self, host: &str) -> Result<Vec<SocketAddr>, Error> {
+		host
+			.to_socket_addrs()
+			.map(|iter| iter.collect())
+			.map_err(|_| Error::DNSResolutionFailed(host.to_string()))
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ pub use self::error::{Error, Result};
 // modules
 mod argc;
 mod can_i_connect;
+mod dns;
 mod error;
 mod helpers;
 mod integration_tests;


### PR DESCRIPTION
refactored and renamed func responsible for getting ip addresses for tcp checks (now called `get_address`) so it supports retrieving ipv6 addresses when there is no existing ipv4 address that exists as a result of the DNS resolution. Also, created new DnsResolver struct and allowed `get_address` to take a resolver as input to allow for mocking for unit tests.